### PR TITLE
Main

### DIFF
--- a/tests/testScript.spec.ts
+++ b/tests/testScript.spec.ts
@@ -3,11 +3,7 @@ import { parseCSV } from "./csvParser";
 import * as km from "./keywordMethods";
 
 const keywords = {
-  URLを開く: km.URLを開く,
-  Pathを確認する: km.Pathを確認する,
-  メニューをクリックする: km.メニューをクリックする,
-  ボタンをクリックする: km.ボタンをクリックする,
-  プラン表示を確認する: km.プラン表示を確認する,
+  ...km,
 };
 
 


### PR DESCRIPTION
キーワード配列にクラスオブジェクトのメソッド都の対応付けを設定する際に、すべてのメソッドを展開するようにしました。